### PR TITLE
Maven central repo URL updated to https

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,30 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
+	
+	<repositories>
+		<repository>
+			<id>repo1.maven</id>
+			<name>Maven Central Repo</name>
+			<url>https://repo.maven.apache.org/maven2/</url>
+		</repository>
+	</repositories>
+	
+	<pluginRepositories>
+		<pluginRepository>
+			<id>spring-snapshots</id>
+			<url>https://repo.spring.io/snapshot</url>
+		</pluginRepository>
+		<pluginRepository>
+			<id>spring-milestones</id>
+			<url>https://repo.spring.io/milestone</url>
+		</pluginRepository>
+		<pluginRepository>
+			<id>repo1.maven</id>
+			<name>Maven Central Repo</name>
+			<url>https://repo.maven.apache.org/maven2/</url>
+		</pluginRepository>
+	</pluginRepositories>
 
 	<build>
 		<plugins>


### PR DESCRIPTION
Due to TLS version upgrade.
Repository URL added explicitly.